### PR TITLE
Fix a number of ShellCheck warnings

### DIFF
--- a/nerdps1
+++ b/nerdps1
@@ -145,7 +145,7 @@ function ps1_get_mseconds
 {
     typeset s __
     [ -r /proc/uptime ] && [ ! "$ps1_use_seconds" ] && {
-        read s __ </proc/uptime
+        read -r s __ </proc/uptime
         echo "${s/[.]/}"
     } || echo "${SECONDS}00"
 }

--- a/nerdps1
+++ b/nerdps1
@@ -3,8 +3,8 @@
 [ "$1" ] && unset ps1_loaded
 [ "$ps1_loaded" ] && return 0
 ps1_loaded=1
-: ${USER:=$USERNAME}
-: ${USER:=$LOGNAME}
+: "${USER:=$USERNAME}"
+: "${USER:=$LOGNAME}"
 export TMPDIR=/tmp
 # check /tmp full
 head -c 25000 /dev/zero >"/tmp/.nerdps1.$USER" 2>/dev/null || {
@@ -29,21 +29,21 @@ ps1_nfstyle2="(/auto:exit_status (/lblack:elapse (/blue:userhost )/lblack:cwd >/
 ps1_pfstyle="/auto:exit_status /lblack:elapse /blue:userhost >/auto:git_branch >/lblack:cwd > | </lblue/black/blue:info </auto:addon </magenta/white:venv </auto:dfcheck </auto:loadavg </auto:freemem </blue:time >"
 
 # overiddable vars in your env or .nerdrc
-#: ${ps1_info_eval:='$(echo uid:$(id -u))'}
-: ${ps1_info_vars:='client_id ORACLE_SID'}
-: ${ps1_info:=''}       # var to add variables to info zone
-: ${ps1_git_status:=1}  # 0 to disable git status
-: ${ps1_exit_colors:="green red"}
-: ${ps1_git_colors:="green yellow/black"}
-: ${ps1_blank_line:=1}
-: ${ps1_fslist:="/ /tmp"} # put "-l" to have all local FS check
-: ${ps1_fslimits:="95 100"}
-: ${ps1_loadlimits:="10 20"}
-: ${ps1_memlimits:="300 100"}
-: ${ps1_url:=https://raw.githubusercontent.com/joknarf/nerdps1/main/nerdps1}
-: ${ps1_powerline:=$ps1_nfstyle}
-: ${ps1_display:=nerd} # nerdicons/powerline/nofont/ascii
-: ${ps1_sshmode:=raw} # pssh mode (1:raw 2:b64 3:cfg 4:url)
+#: "${ps1_info_eval:="$(echo uid:$(id -u))"}"
+: "${ps1_info_vars:="client_id ORACLE_SID"}"
+: "${ps1_info:=""}"       # var to add variables to info zone
+: "${ps1_git_status:=1}"  # 0 to disable git status
+: "${ps1_exit_colors:="green red"}"
+: "${ps1_git_colors:="green yellow/black"}"
+: "${ps1_blank_line:=1}"
+: "${ps1_fslist:="/ /tmp"}" # put "-l" to have all local FS check
+: "${ps1_fslimits:="95 100"}"
+: "${ps1_loadlimits:="10 20"}"
+: "${ps1_memlimits:="300 100"}"
+: "${ps1_url:=https://raw.githubusercontent.com/joknarf/nerdps1/main/nerdps1}"
+: "${ps1_powerline:=$ps1_nfstyle}"
+: "${ps1_display:=nerd}" # nerdicons/powerline/nofont/ascii
+: "${ps1_sshmode:=raw}" # pssh mode (1:raw 2:b64 3:cfg 4:url)
 
 #=========================
 type typeset >/dev/null 2>&1 || alias typeset=local # ash
@@ -161,7 +161,7 @@ function ps1_time_cmd
 function ps1_elapse
 {
     typeset seconds h m s end ms=0
-    : ${__ps1_sec:=-1}
+    : "${__ps1_sec:=-1}"
     [ "$__ps1_sec" = -1 ] && return
     [ "$__ps1_noexec" ] && return
     end=$(ps1_get_mseconds)
@@ -184,7 +184,7 @@ function ps1_elapse
 function ps1_pwline {
     : ${COLUMNS:=$(stty size 2>/dev/null)} # ash no $COLUMNS
     COLUMNS=${COLUMNS#* }
-    : ${ps1_colors:="blue lblack green yellow/black lblue/black"} # just some defaults
+    : "${ps1_colors:="blue lblack green yellow/black lblue/black"}" # just some defaults
     $ps1_awk -v pcol="$ps1_colors" -v columns="$COLUMNS" -v nopw="$ps1_nopw" -v kshbug="$ps1_kshbug" '
     function init_symbols(  symbols,ts) {
         if (nopw==0) {
@@ -444,7 +444,7 @@ function ps1_osinfo {
     [ -f /etc/os-release ] && . /etc/os-release || {
         [ -f /etc/redhat-release ] && ID=$($ps1_awk '{sub("Red","rh", $1);print $1$(NF-1);exit(0);}' /etc/redhat-release)
     }
-    : ${ID:=$(uname -s)}
+    : "${ID:=$(uname -s)}"
     [ "$ID" = "Darwin" ] && ID=$(sw_vers |awk -F':\t*' '$1=="ProductName"{s=$2}$1=="ProductVersion"{v=$2}END{print s v}')
     [ "$ID" = "SunOS" ] && ID=$(uname -r) && ID="solaris${ID#*.}"
     ps1_osinfo="${ID%%.*}"
@@ -554,17 +554,17 @@ function ps1_set {
     ps1_osinfo
     if [ "$BASH" ];then
         shopt -s checkwinsize 2>/dev/null
-        : ${PROMPT_DIRTRIM:=5}
+        : "${PROMPT_DIRTRIM:=5}"
     elif [ "$ZSH_VERSION" ];then
         setopt PROMPT_SUBST
     else
         ps1_hostname=$(uname -n)
         ps1_hostname=${ps1_hostname%%.*}
-        [ "$BB_ASH_VERSION$KSH_VERSION" ] || : ${ps1_kshbug:=1}
-        [[ "$KSH_VERSION" = *2012* ]] && : ${ps1_kshbug:=1}
-        : ${ps1_kshbug:=0}
+        [ "$BB_ASH_VERSION$KSH_VERSION" ] || : "${ps1_kshbug:=1}"
+        [[ "$KSH_VERSION" = *2012* ]] && : "${ps1_kshbug:=1}"
+        : "${ps1_kshbug:=0}"
     fi
-    [[ $(uname -r ) = *-ish ]] && : ${ps1_use_seconds:=1}
+    [[ $(uname -r ) = *-ish ]] && : "${ps1_use_seconds:=1}"
     PS1_OLD="$PS1"
     PS1=$(ps1_prompt "$ps1_powerline")
     [ "$ps1_blank_line" = 1 ] && PS1="
@@ -590,7 +590,7 @@ function ps1_phelp {
 function psudo {
     [ "$1" = "-h" ] && ps1_phelp "psudo [-b] [-g] [-u] [<user>]" && return
     ps1_user="$*";ps1_user=${ps1_user##*-[a-z] };ps1_user=${ps1_user% *}
-    : ${ps1_user:=root}
+    : "${ps1_user:=root}"
     sudo -u "$ps1_user" -H $(ps1_login -e "$@")
 }
 

--- a/nerdps1
+++ b/nerdps1
@@ -1,5 +1,5 @@
 #!/bin/bash
-[ "$1" = activate ] && unset ps1_loaded && awk 'NR>2' $0 && exit 0
+[ "$1" = activate ] && unset ps1_loaded && awk 'NR>2' "$0" && exit 0
 [ "$1" ] && unset ps1_loaded
 [ "$ps1_loaded" ] && return 0
 ps1_loaded=1
@@ -7,15 +7,15 @@ ps1_loaded=1
 : ${USER:=$LOGNAME}
 export TMPDIR=/tmp
 # check /tmp full
-head -c 25000 /dev/zero >/tmp/.nerdps1.$USER 2>/dev/null || {
+head -c 25000 /dev/zero >"/tmp/.nerdps1.$USER" 2>/dev/null || {
     export TMPPREFIX=/var/tmp/zsh
     export TMPDIR=/var/tmp
 }
 ps1_tmp=$TMPDIR/.nerdps1.$USER
-[ -e "$ps1_tmp" ] && ! chmod 0644 $ps1_tmp 2>/dev/null && echo "Warning! not owner of $ps1_tmp." >&2 && ps1_tmp=$ps1_tmp.$$
-rm $ps1_tmp.profile/.nerdrc 2>/dev/null
+[ -e "$ps1_tmp" ] && ! chmod 0644 "$ps1_tmp" 2>/dev/null && echo "Warning! not owner of $ps1_tmp." >&2 && ps1_tmp=$ps1_tmp.$$
+rm "$ps1_tmp.profile/.nerdrc" 2>/dev/null
 [ -r ~/.nerdrc ] && [ ! "$1" = login ] && . ~/.nerdrc
-(umask 0022; cat - >$ps1_tmp) <<'EOF' || exit 1
+(umask 0022; cat - >"$ps1_tmp") <<'EOF' || exit 1
 ######## powerline-awk ##########
 # Author: Franck Jouvanceau
 # Powerline prompt with AWK (bash/zsh/ksh)
@@ -54,7 +54,7 @@ echo ok |base64 -w 0 >/dev/null 2>&1 && ps1_b64opt="-w0"
 
 function ps1_usershell {
     typeset shell=$(getent passwd "$1" 2>/dev/null)
-    echo ${shell##*:}
+    echo "${shell##*:}"
 }
 
 function ps1_bashinit {
@@ -111,22 +111,22 @@ function ps1_login {
         [ "$i" = "-e" ] && shift && exec=""
     done
     [ "$3" ] && profdir="$3"
-    [ -e "$profdir" ] && ! chmod 0711 $profdir 2>/dev/null && echo "Warning! not owner of $profdir" >&2 && profdir=$profdir.$$
-    (umask 0066;mkdir -p $profdir)
-    [[ $ps1_tmp != *.$USER ]] && cp -p $ps1_tmp.profile/.nerdrc $profdir 2>/dev/null
+    [ -e "$profdir" ] && ! chmod 0711 "$profdir" 2>/dev/null && echo "Warning! not owner of $profdir" >&2 && profdir=$profdir.$$
+    (umask 0066;mkdir -p "$profdir")
+    [[ $ps1_tmp != *.$USER ]] && cp -p "$ps1_tmp.profile/.nerdrc" "$profdir" 2>/dev/null
     typeset nerdps1="ps1_tmp=$ps1_tmp;export TMPDIR=$TMPDIR;. $ps1_tmp reload"
     typeset load_custom="[ -r '$profdir/.nerdrc' ] && . '$profdir/.nerdrc'"
     #[ "${1-$USER}" = "$USER" ] || cp -p ~/.nerdrc $profdir 2>/dev/null
-    [ "$ps1_user" ]  && [ "$ps1_user" != "$USER" ] && cp -p ~/.nerdrc $profdir 2>/dev/null
-    [ "$ps1_shell" ] || ps1_shell=$(ps1_usershell $1)
-    [ "$2" ] && [ -r "$2" ] && cp -p $2 $profdir/.nerdrc
+    [ "$ps1_user" ]  && [ "$ps1_user" != "$USER" ] && cp -p ~/.nerdrc "$profdir" 2>/dev/null
+    [ "$ps1_shell" ] || ps1_shell=$(ps1_usershell "$1")
+    [ "$2" ] && [ -r "$2" ] && cp -p "$2" "$profdir/.nerdrc"
     (umask 0022;(
         echo "_gprof=$gprofile;_uprof=$uprofile"
         echo "ps1_powerline='$ps1_powerline'"
         echo "ps1_info='$ps1_info'"
         echo "ps1_loaded=1"
     ) > "$profdir/.rc") || return 1
-    ln -s .rc $profdir/.zshrc 2>/dev/null
+    ln -s .rc "$profdir/.zshrc" 2>/dev/null
     case "$ps1_shell" in
         */*ksh) ps1_kshinit >>"$profdir/.rc"
              echo "ENV=$profdir/.rc $exec $ps1_shell -i";;
@@ -146,7 +146,7 @@ function ps1_get_mseconds
     typeset s __
     [ -r /proc/uptime ] && [ ! "$ps1_use_seconds" ] && {
         read s __ </proc/uptime
-        echo ${s/[.]/}
+        echo "${s/[.]/}"
     } || echo "${SECONDS}00"
 }
 
@@ -328,7 +328,7 @@ function ps1_git_branch {
 function ps1_userhost {
     typeset hostname
     hostname=$(uname -n)
-    echo $USER@${hostname%%.*}
+    echo "$USER@${hostname%%.*}"
 }
 
 function ps1_cwd {
@@ -379,7 +379,7 @@ function ps1_info {
     typeset infos i
     infos=$(eval echo \""$ps1_info_eval"\")
     # cannot use zsh ${=ps1_info_vars} as ksh error
-    [ "$ZSH_VERSION" ] && set -- $(echo $ps1_info_vars) || set -- $ps1_info_vars
+    [ "$ZSH_VERSION" ] && set -- $(echo "$ps1_info_vars") || set -- $ps1_info_vars
     for i in "$@" $ps1_info;do
         infos=$infos$(eval echo \"'|$'"$i"\")
     done
@@ -398,7 +398,7 @@ function ps1_freemem {
     [ -r /proc/meminfo ] && cmd='cat /proc/meminfo'
     [ ! "$cmd" ] && [ -r /var/run/dmesg.boot ] && cmd='grep avail.memory /var/run/dmesg.boot'
     [ ! "$cmd" ] && return
-    eval $cmd |$ps1_awk -v limits="$ps1_memlimits" '
+    eval "$cmd" |$ps1_awk -v limits="$ps1_memlimits" '
         /MemAvailable:/ { avail = $2 }
         /Buffer:|Cached:|MemFree:/ { free += $2 }
         /page size of/ { ps=$(NF-1) }
@@ -435,8 +435,8 @@ function ps1_loadavg {
     load=${load%% *}
     loadint=${load%.*}
     [ ! "$load" ] && return
-    [ $loadint -ge ${ps1_loadlimits#* } ] && echo "red///error:$load" && return
-    [ $loadint -ge ${ps1_loadlimits% *} ] && echo "yellow/black//warn:$load" && return
+    [ "$loadint" -ge "${ps1_loadlimits#* }" ] && echo "red///error:$load" && return
+    [ "$loadint" -ge "${ps1_loadlimits% *}" ] && echo "yellow/black//warn:$load" && return
     echo "green:$load"
 }
 
@@ -598,7 +598,7 @@ function ps1_sshcmd
 {
     typeset loginopts="$1" customenv="$2" nerdps1="$3" custom
     [ "$nerdps1" ] || nerdps1='$ps1_tmp'
-    [ -r $TMPDIR/.nerdps1.$USER.profile/.nerdrc ] && custom=$TMPDIR/.nerdps1.$USER.profile/.nerdrc
+    [ -r "$TMPDIR/.nerdps1.$USER.profile/.nerdrc" ] && custom=$TMPDIR/.nerdps1.$USER.profile/.nerdrc
     [ -r ~/.nerdrc ] && custom=~/.nerdrc
     [ "$customenv" ] && custom=$customenv
     printf "%s" "
@@ -608,7 +608,7 @@ function ps1_sshcmd
         ps1_tmp=\$TMPDIR/.nerdps1.\$USER
         [ -e \$ps1_tmp ] && ! chmod 0644 \$ps1_tmp 2>/dev/null && echo \"Warning! not owner of \$ps1_tmp.\" >&2 && ps1_tmp=\$ps1_tmp.\$\$
         (umask 0022;cat - >\$ps1_tmp) <<'EOF$$' || exit 1
-$(cat $ps1_tmp)
+$(cat "$ps1_tmp")
 EOF$$
         profdir=\$ps1_tmp.profile
         [ -e \$profdir ] && ! chmod 0711 \$profdir 2>/dev/null && echo \"Warning! not owner of \$profdir\" >&2 && profdir=\$profdir.$$
@@ -644,7 +644,7 @@ function pssh
         1|raw) ssh -t "$remote" "$@" "$(ps1_sshcmd "$loginopts" "$customenv")";;
         2|b64) ssh -t "$remote" "$@" ". <(echo $(ps1_sshcmd "$loginopts" "$customenv"| gzip -c| base64 $ps1_b64opt) |base64 -d|gzip -dc)";;
         3|cfg) ps1_pssh3 "$remote" "$loginopts" "$customenv" "$@";;
-        4|url) ssh -t $remote "$@" "$(ps1_sshcmd "$loginopts" "$customenv" "<(curl -Ls -m 6 $ps1_url)")";;
+        4|url) ssh -t "$remote" "$@" "$(ps1_sshcmd "$loginopts" "$customenv" "<(curl -Ls -m 6 $ps1_url)")";;
     esac
 }
 
@@ -655,21 +655,21 @@ psshu() { pssh --url "$@"; }
 function ps1_pssh3 {
     typeset remote="$1" loginopts="$2" customenv="$3" ssh_config=$TMPDIR/.nerdps1.$USER.ssh argf=false
     shift 3
-    (umask 077;echo "RemoteCommand . <(echo $(ps1_sshcmd "$loginopts" "$customenv"| gzip -c| base64 $ps1_b64opt) |base64 -d|gzip -dc)" >$ssh_config) || return 1
+    (umask 077;echo "RemoteCommand . <(echo $(ps1_sshcmd "$loginopts" "$customenv"| gzip -c| base64 $ps1_b64opt) |base64 -d|gzip -dc)" >"$ssh_config") || return 1
     # include ssh config if -F ssh option
     for arg in "$@";do
        shift
        [ "$arg" = -F ] && argf=true && continue
        $argf && argf=false && sshc=$arg && continue
        [[ "$arg" == -F* ]] && sshc=${arg#-F} && continue
-       set -- "$@" $arg
+       set -- "$@" "$arg"
     done
     [ "$sshc" ] && {
-        [ -r "$sshc" ] && cat "$sshc" >>$ssh_config 2>/dev/null
+        [ -r "$sshc" ] && cat "$sshc" >>"$ssh_config" 2>/dev/null
     } || { # add user ssh config if no -F option
-        [ -r ~/.ssh/config ] && cat ~/.ssh/config >>$ssh_config
+        [ -r ~/.ssh/config ] && cat ~/.ssh/config >>"$ssh_config"
     }
-    ssh -t "$remote" -F $ssh_config "$@"
+    ssh -t "$remote" -F "$ssh_config" "$@"
 }
 
 
@@ -693,5 +693,5 @@ return 0
 EOF
 
 unset ps1_loaded
-. $ps1_tmp "$@"
+. "$ps1_tmp" "$@"
 :

--- a/nerdps1
+++ b/nerdps1
@@ -26,12 +26,12 @@ ps1_loaded=1
 
 ps1_nfstyle="(/auto:exit_status (/lblack:elapse (/blue:userhost )/auto:git_branch )/lblack:cwd > | (/lblue/black/blue:info (/auto:addon (/magenta/white:venv (/auto:dfcheck (/auto:loadavg (/auto:freemem (/blue:time )"
 ps1_nfstyle2="(/auto:exit_status (/lblack:elapse (/blue:userhost )/lblack:cwd >/auto:git_branch > | (/lblue/black/blue:info (/auto:addon (/magenta/white:venv (/auto:dfcheck (/auto:loadavg (/auto:freemem (/blue:time )"
-ps1_pfstyle="/auto:exit_status /lblack:elapse /blue:userhost >/auto:git_branch >/lblack:cwd > | </lblue/black/blue:info </auto:addon </magenta/white:venv </auto:dfcheck </auto:loadavg </auto:freemem </blue:time >" 
+ps1_pfstyle="/auto:exit_status /lblack:elapse /blue:userhost >/auto:git_branch >/lblack:cwd > | </lblue/black/blue:info </auto:addon </magenta/white:venv </auto:dfcheck </auto:loadavg </auto:freemem </blue:time >"
 
 # overiddable vars in your env or .nerdrc
 #: ${ps1_info_eval:='$(echo uid:$(id -u))'}
 : ${ps1_info_vars:='client_id ORACLE_SID'}
-: ${ps1_info:=''}       # var to add variables to info zone  
+: ${ps1_info:=''}       # var to add variables to info zone
 : ${ps1_git_status:=1}  # 0 to disable git status
 : ${ps1_exit_colors:="green red"}
 : ${ps1_git_colors:="green yellow/black"}
@@ -46,7 +46,7 @@ ps1_pfstyle="/auto:exit_status /lblack:elapse /blue:userhost >/auto:git_branch >
 : ${ps1_sshmode:=raw} # pssh mode (1:raw 2:b64 3:cfg 4:url)
 
 #=========================
-type typeset >/dev/null 2>&1 || alias typeset=local # ash 
+type typeset >/dev/null 2>&1 || alias typeset=local # ash
 [ -x /bin/nawk ] && ps1_awk=nawk || ps1_awk=awk
 echo ok |base64 -w 0 >/dev/null 2>&1 && ps1_b64opt="-w0"
 
@@ -130,7 +130,7 @@ function ps1_login {
     case "$ps1_shell" in
         */*ksh) ps1_kshinit >>"$profdir/.rc"
              echo "ENV=$profdir/.rc $exec $ps1_shell -i";;
-        */zsh) ps1_zshinit >>"$profdir/.rc"  
+        */zsh) ps1_zshinit >>"$profdir/.rc"
              echo "ZDOTDIR=$profdir $exec $ps1_shell -di";;
         *)   ps1_bashinit >>"$profdir/.rc"
              echo "$exec bash --init-file $profdir/.rc"
@@ -295,7 +295,7 @@ function ps1_pwline {
             gsub("[|]", colors[sepc[i]] sep[symb[i]] colors[fgs[i]], txt[i])
             if (rev[symb[i]]) {
                 printf("%s", colors[bgs[i]] sym[symb[i]])
-                if (txt[i] != symb[i]) 
+                if (txt[i] != symb[i])
                     printf("%s", colors[fgs[i]] colors["b"bgs[i]] icos[i] " " txt[i] " " colors[bgs[i]])
             } else {
                 printf("%s", colors["b"bgs[i]] sym[symb[i]])
@@ -363,13 +363,13 @@ function ps1_dfcheck {
         if (warn) { print("yellow/black//warn:"msg); exit(1); }
     }'
 }
-# zsh 
+# zsh
 function ps1_preexec {
     __ps1_preexec=1
     __ps1_sec=$(ps1_get_mseconds)
 }
 
-# zsh 
+# zsh
 function ps1_precmd {
     [ "$__ps1_preexec" ] && unset __ps1_noexec || __ps1_noexec=1
     unset __ps1_preexec
@@ -389,7 +389,7 @@ function ps1_info {
 type ps1_addon >/dev/null 2>&1 || ps1_addon() { :; }
 
 function ps1_uidprompt {
-    [ "$USER" = root ] && echo '#' || echo '$'    
+    [ "$USER" = root ] && echo '#' || echo '$'
 }
 
 function ps1_freemem {
@@ -434,7 +434,7 @@ function ps1_loadavg {
     }
     load=${load%% *}
     loadint=${load%.*}
-    [ ! "$load" ] && return 
+    [ ! "$load" ] && return
     [ $loadint -ge ${ps1_loadlimits#* } ] && echo "red///error:$load" && return
     [ $loadint -ge ${ps1_loadlimits% *} ] && echo "yellow/black//warn:$load" && return
     echo "green:$load"
@@ -606,14 +606,14 @@ function ps1_sshcmd
         head -c 25000 /dev/zero >/tmp/.nerdps1.\$USER 2>/dev/null || export TMPDIR=/var/tmp
         export TMPPREFIX=\$TMPDIR/zsh
         ps1_tmp=\$TMPDIR/.nerdps1.\$USER
-        [ -e \$ps1_tmp ] && ! chmod 0644 \$ps1_tmp 2>/dev/null && echo \"Warning! not owner of \$ps1_tmp.\" >&2 && ps1_tmp=\$ps1_tmp.\$\$ 
+        [ -e \$ps1_tmp ] && ! chmod 0644 \$ps1_tmp 2>/dev/null && echo \"Warning! not owner of \$ps1_tmp.\" >&2 && ps1_tmp=\$ps1_tmp.\$\$
         (umask 0022;cat - >\$ps1_tmp) <<'EOF$$' || exit 1
 $(cat $ps1_tmp)
 EOF$$
         profdir=\$ps1_tmp.profile
         [ -e \$profdir ] && ! chmod 0711 \$profdir 2>/dev/null && echo \"Warning! not owner of \$profdir\" >&2 && profdir=\$profdir.$$
 	    (umask 0066;mkdir -p \$profdir)
-        (umask 0022;cat - >\$profdir/.nerdrc) <<'EOF$$' 
+        (umask 0022;cat - >\$profdir/.nerdrc) <<'EOF$$'
 $([ "$custom" ] && cat "$custom")
 EOF$$
         . $nerdps1 login $loginopts \$USER '' \$profdir
@@ -682,7 +682,7 @@ if [ "$ZSH_VERSION" ] ; then
     add-zsh-hook precmd ps1_precmd
 elif [ "$BASH" ] ; then
     [[ "$BASH_VERSION" > "4.4" ]] && PS0='${_:$((__ps1_sec=$(ps1_get_mseconds), 0)):0}' || trap ps1_time_cmd DEBUG
-else 
+else
     [ "$ps1_kshbug" = 0 ] && trap ps1_time_cmd DEBUG 2>/dev/null
 fi
 

--- a/nerdps1
+++ b/nerdps1
@@ -335,7 +335,7 @@ function ps1_cwd {
     typeset spwd cols
     spwd=$PWD
     cols=${COLUMNS:-80}
-    case "$PWD" in $HOME|$HOME/*) spwd="~${PWD#$HOME}";; esac
+    case "$PWD" in "$HOME"|"$HOME"/*) spwd="~${PWD#"$HOME"}";; esac
     [ ${#spwd} -gt $(($cols-30)) ] && spwd="${spwd:0:7}...${spwd:$((${#spwd}-$cols-40))}"
     echo "$spwd"
 }


### PR DESCRIPTION
I have put the script through ShellCheck and fixed the most conspicuous warnings - in particular those related to quoting, as unintended globbing and word splitting can lead to unforeseen consequences.